### PR TITLE
Allow element rendered by Provider to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ const App = () => (
 
 ### Provider
 
-retranslate is configured using the `Provider`. You pass `Provider` `messages`, a `language` and a `fallbackLanguage` (just in case). Wrap your application with `Provider` to make retranslate work.
+retranslate is configured using the `Provider`. You pass `Provider` `messages`, a `language` and a `fallbackLanguage` (just in case). Wrap your application with `Provider` to make retranslate work. The `Provider` takes an optional argument `wrapperElement`, which can be used to configure which element is used to render the provider. This can either be a string
+to use a DOM element (e.g. `<Provider wrapperElement="span">`) or some react element (e.g. `<Provider wrapperElement={React.Fragment}>`).
 
 ### Message
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "retranslate",
   "description": "Real simple translations for react.",
   "main": "build/retranslate.js",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tankenstein/retranslate/issues",

--- a/src/provider/Provider.js
+++ b/src/provider/Provider.js
@@ -31,7 +31,8 @@ class Provider extends Component {
   }
 
   render() {
-    return <div>{this.props.children}</div>;
+    const element = this.props.wrapperElement || 'div';
+    return React.createElement(element, {}, this.props.children);
   }
 }
 
@@ -44,6 +45,10 @@ Provider.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.element,
     PropTypes.arrayOf(PropTypes.element),
+    PropTypes.string,
+  ]),
+  wrapperElement: PropTypes.oneOfType([
+    PropTypes.func,
     PropTypes.string,
   ]),
 };

--- a/src/provider/Provider.spec.js
+++ b/src/provider/Provider.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import Provider from './Provider';
 
 describe('Translation Provider', () => {
@@ -27,6 +27,33 @@ describe('Translation Provider', () => {
   it('renders children given to it', () => {
     component = shallow(<Provider {...props}>Hello!</Provider>);
     expect(component.text()).toEqual('Hello!');
+  });
+
+  it('renders using span as wrapper', () => {
+    component = shallow(<Provider {...props} wrapperElement="span">Hello!</Provider>);
+    expect(component.text()).toEqual('Hello!');
+    expect(component.type()).toEqual('span');
+  });
+
+  it('renders using a function component as wrapper', () => {
+    function Wrapper({ children }) {
+      return <div className="function-wrapper">{ children }</div>
+    }
+    component = shallow(<Provider {...props} wrapperElement={Wrapper}>Hello!</Provider>);
+    expect(component.html()).toEqual(
+      '<div class="function-wrapper">Hello!</div>'
+    );
+  });
+  it('renders using a class component as wrapper', () => {
+    class Wrapper extends React.Component {
+      render() {
+        return <div className="class-wrapper">{ this.props.children }</div>
+      }
+    }
+    component = mount(<Provider {...props} wrapperElement={Wrapper}>Hello!</Provider>);
+    expect(component.html()).toEqual(
+      '<div class="class-wrapper">Hello!</div>'
+    );
   });
 
   it('translates strings in different languages', () => {


### PR DESCRIPTION
The default `<div>` wrapper isn't valid anywhere in the DOM. By allowing
the wrapper element to be configured it is possible for the user to
change it to something else when needed.

An example use case for this are component libraries with bundled
translations. If a component is intended to be used as phrasing content
then it can't introduce a `<div>`. Moving the `Provider` higher up
the tree isn't possible here, as this falls out of the scope of the
library.