### PR TITLE
Add render-prop version of `withTranslations`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ const LanguageShower = withTranslations(({ translations: { translate, language }
   <p>{translate('current.language', { currentLanguage: language })}</p>
 ));
 
+// withTranslations is also available through a render prop with <WithTranslations>
+const AnotherLanguageShower = () => (
+  <WithTranslations>{({ translate, language }) =>(
+    <p>{translate('current.language', { currentLanguage: language })}</p>
+  )}</WithTranslations>
+)
+
 const App = () => (
   <TranslationProvider messages={translations} language={getLanguage()} fallbackLanguage="en">
     <h1><Message params={{ versionNumber: version }}>main.heading</Message></h1>
@@ -47,6 +54,7 @@ const App = () => (
     <Message className="lead">main.subtitle</Message> // you can apply classes to the translated string
     <Message dangerouslyTranslateInnerHTML="bold.thing" /> // this does not escape HTML. Dangerous to use, be careful.
     <LanguageShower />
+    <AnotherLanguageShower />
   </TranslationProvider>
 );
 ```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "retranslate",
   "description": "Real simple translations for react.",
   "main": "build/retranslate.js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tankenstein/retranslate/issues",

--- a/src/WithTranslationsComponent/WithTranslations.js
+++ b/src/WithTranslationsComponent/WithTranslations.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import { PropTypes } from 'react';
 import withTranslations from '../withTranslations';
 import { TranslationContext } from '../common/PropTypes';
 
@@ -21,11 +21,11 @@ import { TranslationContext } from '../common/PropTypes';
  * }
  */
 const WithTranslations = withTranslations(({ children, translations }) => (
-	children(translations))
+  children(translations)),
 );
 WithTranslations.displayName = 'WithTranslations';
 WithTranslations.propTypes = {
-  children: PropTypes.func.isRequired
+  children: PropTypes.func.isRequired,
 };
 WithTranslations.contextTypes = TranslationContext;
 

--- a/src/WithTranslationsComponent/WithTranslations.js
+++ b/src/WithTranslationsComponent/WithTranslations.js
@@ -1,0 +1,32 @@
+import React, { PropTypes } from 'react';
+import withTranslations from '../withTranslations';
+import { TranslationContext } from '../common/PropTypes';
+
+/**
+ * Component that wraps the `withTranslations` hoc in a render prop.
+ * Using `withTranslations` through a render prop eliminates name collisions
+ * on props, as well as makes it easier to use in typed languages such as flow
+ * or typescript.
+ *
+ * render() {
+ *   return (
+ *     <TranslationProvider>
+ *       <WithTranslations>{({ language, translate }) => (
+ *        The current language is <em>{ language }</em>.
+ *
+ *        { translate('with-translations-example.hello-world') }
+ *       )</WithTranslations>
+ *     </TranslationProvider>
+ *   )
+ * }
+ */
+const WithTranslations = withTranslations(({ children, translations }) => (
+	children(translations))
+);
+WithTranslations.displayName = 'WithTranslations';
+WithTranslations.propTypes = {
+  children: PropTypes.func.isRequired
+};
+WithTranslations.contextTypes = TranslationContext;
+
+export default WithTranslations;

--- a/src/WithTranslationsComponent/WithTranslations.spec.js
+++ b/src/WithTranslationsComponent/WithTranslations.spec.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import WithTranslations from './WithTranslations';
+import { mount } from 'enzyme';
+import Provider from '../provider';
+
+const messages = {
+  en : {},
+};
+
+describe('WithTranslations', () => {
+  it('should call the render function with a translations object', () => {
+    const childFunc = jest.fn();
+    childFunc.mockReturnValue(<h1>foo</h1>);
+    mount(
+      <Provider messages={messages} language="en">
+        <WithTranslations>{childFunc}</WithTranslations>
+      </Provider>
+    );
+    expect(childFunc).toBeCalled();
+    const argument = childFunc.mock.calls[0][0];
+    expect(argument.language).toBe('en');
+    expect(argument.translate).toBeDefined();
+  });
+
+  it('should render the return value of the render function', () => {
+    const rendered = mount(
+      <Provider messages={messages} language="en">
+        <WithTranslations>{() => <h1>Test</h1>}</WithTranslations>
+      </Provider>
+    );
+    expect(rendered.html()).toEqual('<div><h1>Test</h1></div>');
+  });
+});

--- a/src/WithTranslationsComponent/index.js
+++ b/src/WithTranslationsComponent/index.js
@@ -1,0 +1,3 @@
+import WithTranslations from './WithTranslations';
+
+export default WithTranslations;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 import MessageModule from './message';
 import ProviderModule from './provider';
+import WithTranslationsComponentModule from './WithTranslationsComponent';
 import withTranslationsModule from './withTranslations';
 
 export const Message = MessageModule;
 export const Provider = ProviderModule;
 export const withTranslations = withTranslationsModule;
+export const WithTranslations = WithTranslationsComponentModule;


### PR DESCRIPTION
With render-props we won't have naming collision, and they also play
nicer with typed languages.