### PR TITLE
Stop including prop types in the bundle

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,5 +6,13 @@
       "plugins": ["@babel/plugin-proposal-object-rest-spread"]
     }
   },
-  "plugins": ["@babel/plugin-proposal-object-rest-spread"]
+  "plugins": [
+    "@babel/plugin-proposal-object-rest-spread",
+    [
+      "babel-plugin-transform-react-remove-prop-types",
+      {
+        "removeImport": true
+      }
+    ]
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "retranslate",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1812,6 +1812,12 @@
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
+    "babel-plugin-transform-react-remove-prop-types": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.15.tgz",
+      "integrity": "sha512-bFxxYdkZBwTjTgtZEPTLqu9g8Ajz8x8uEP/O1iVuaZIz2RuxJ2gtx0EXDJRonC++KGsgsW/4Hqvk4KViEtE2nw==",
+      "dev": true
+    },
     "babel-preset-jest": {
       "version": "23.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.4.2",
     "babel-loader": "^8.0.0-beta.4",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.15",
     "coveralls": "^3.0.2",
     "enzyme": "^3.4.4",
     "enzyme-adapter-react-16": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "retranslate",
   "description": "Real simple translations for react.",
   "main": "dist/retranslate.js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tankenstein/retranslate/issues",


### PR DESCRIPTION
Mainly used for documentation, stripped in prod for easier usage and lighter bundle size.