### PR TITLE
Remove extra wrapper in translations context

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "retranslate",
   "description": "Real simple translations for react.",
   "main": "dist/retranslate.js",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tankenstein/retranslate/issues",

--- a/src/WithTranslations.spec.js
+++ b/src/WithTranslations.spec.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { WithTranslations, Provider } from '.';
+
+const messages = {
+  en: {},
+};
+
+describe('WithTranslations', () => {
+  it('should call the render function with a translations object', () => {
+    const childFunc = jest.fn();
+    childFunc.mockReturnValue(<h1>foo</h1>);
+    mount(
+      <Provider messages={messages} language="en">
+        <WithTranslations>{childFunc}</WithTranslations>
+      </Provider>,
+    );
+    expect(childFunc).toBeCalled();
+    const argument = childFunc.mock.calls[0][0];
+    expect(argument.language).toBe('en');
+    expect(argument.translate).toBeDefined();
+  });
+
+  it('should render the return value of the render function', () => {
+    const rendered = mount(
+      <Provider messages={messages} language="en">
+        <WithTranslations>{() => <h1>Test</h1>}</WithTranslations>
+      </Provider>,
+    );
+    expect(rendered.html()).toEqual('<h1>Test</h1>');
+  });
+});

--- a/src/message/Message.js
+++ b/src/message/Message.js
@@ -5,7 +5,7 @@ import { Consumer as ContextConsumer } from '../common/context';
 
 const Message = ({ children, params, dangerouslyTranslateInnerHTML }) => (
   <ContextConsumer>
-    {({ translations }) => {
+    {translations => {
       if (!dangerouslyTranslateInnerHTML) {
         return translations
           .translateAsParts(children, params)

--- a/src/message/Message.spec.js
+++ b/src/message/Message.spec.js
@@ -19,7 +19,7 @@ describe('Message', () => {
       { dangerous: false, value: 'translated ' },
       { dangerous: true, value: 'value' },
     ]);
-    const context = { translations: { translateAsParts } };
+    const context = { translateAsParts };
     const component = render(<Message>message.id</Message>, context);
     expect(translateAsParts).toHaveBeenCalledTimes(1);
     expect(translateAsParts).toHaveBeenCalledWith('message.id', {});
@@ -31,7 +31,7 @@ describe('Message', () => {
       { dangerous: false, value: 'translated value ' },
       { dangerous: true, value: params.test },
     ]);
-    const context = { translations: { translateAsParts } };
+    const context = { translateAsParts };
     const component = render(<Message params={{ test: 'hello' }}>message.id</Message>, context);
     expect(translateAsParts).toHaveBeenCalledTimes(1);
     expect(translateAsParts).toHaveBeenCalledWith('message.id', { test: 'hello' });
@@ -41,7 +41,7 @@ describe('Message', () => {
   it('translates with sanitized html', () => {
     const html = '<h1>this is a heading<b>with bold</b></h1>';
     const translateAsParts = jest.fn(() => [{ dangerous: false, value: html }]);
-    const context = { translations: { translateAsParts } };
+    const context = { translateAsParts };
     const component = render(<Message>message.id</Message>, context);
     expect(component.html()).toBe(
       '&lt;h1&gt;this is a heading&lt;b&gt;with bold&lt;/b&gt;&lt;/h1&gt;',
@@ -53,7 +53,7 @@ describe('Message', () => {
       { dangerous: false, value: '<h1>some safe html</h1>' },
       { dangerous: true, value: '<span>some sketchy user input</span>' },
     ]);
-    const context = { translations: { translateAsParts } };
+    const context = { translateAsParts };
     const component = render(<Message dangerouslyTranslateInnerHTML="message.id" />, context);
     expect(component.html()).toBe(
       '<span><h1>some safe html</h1></span>&lt;span&gt;some sketchy user input&lt;/span&gt;',
@@ -65,7 +65,7 @@ describe('Message', () => {
       { dangerous: false, value: 'just some ' },
       { dangerous: true, value: 'text' },
     ]);
-    const context = { translations: { translateAsParts } };
+    const context = { translateAsParts };
     const component = render(<Message asString>message.id</Message>, context);
     expect(component.html()).toBe('just some text');
   });

--- a/src/provider/Provider.js
+++ b/src/provider/Provider.js
@@ -50,11 +50,9 @@ class Provider extends Component {
   getContext() {
     const { language } = this.props;
     return {
-      translations: {
-        language,
-        translateAsParts: this.translateAsParts.bind(this),
-        translate: this.translate.bind(this),
-      },
+      language,
+      translateAsParts: this.translateAsParts.bind(this),
+      translate: this.translate.bind(this),
     };
   }
 

--- a/src/provider/Provider.spec.js
+++ b/src/provider/Provider.spec.js
@@ -12,11 +12,11 @@ describe('Translation Provider', () => {
   }
 
   function translate(key, params) {
-    return context.translations.translateAsParts(key, params);
+    return context.translateAsParts(key, params);
   }
 
   function translateAsString(key, params) {
-    return context.translations.translate(key, params);
+    return context.translate(key, params);
   }
 
   beforeEach(() => {
@@ -41,14 +41,14 @@ describe('Translation Provider', () => {
     };
     component.setProps(props);
     getNewInstanceContext();
-    expect(context.translations.language).toEqual('firstLanguage');
+    expect(context.language).toEqual('firstLanguage');
     expect(translate('one')).toEqual([{ dangerous: false, value: 'firstLanguageOne' }]);
     expect(translate('two')).toEqual([{ dangerous: false, value: 'firstLanguageTwo' }]);
 
     props.language = 'secondLanguage';
     component.setProps(props);
     getNewInstanceContext();
-    expect(context.translations.language).toEqual('secondLanguage');
+    expect(context.language).toEqual('secondLanguage');
     expect(translate('one')).toEqual([{ dangerous: false, value: 'secondLanguageOne' }]);
     expect(translate('two')).toEqual([{ dangerous: false, value: 'secondLanguageTwo' }]);
   });
@@ -60,7 +60,7 @@ describe('Translation Provider', () => {
     component.setProps(props);
     getNewInstanceContext();
     expect(translate('message')).toEqual([{ dangerous: false, value: 'hey' }]);
-    expect(context.translations.language).toEqual('firstLanguage');
+    expect(context.language).toEqual('firstLanguage');
   });
 
   it('interpolates variables', () => {

--- a/src/withTranslations/withTranslations.js
+++ b/src/withTranslations/withTranslations.js
@@ -9,7 +9,7 @@ function getDisplayName(WrappedComponent) {
 export default function withTranslations(WrappedComponent) {
   const WithTranslations = props => (
     <ContextConsumer>
-      {({ translations }) => {
+      {translations => {
         const wrappedProps = {
           // translations are passed first, so user can override.
           translations,

--- a/src/withTranslations/withTranslations.spec.js
+++ b/src/withTranslations/withTranslations.spec.js
@@ -21,10 +21,8 @@ describe('withTranslations higher order component', () => {
 
   beforeEach(() => {
     testContext = {
-      translations: {
-        language: 'language',
-        translate: jest.fn(),
-      },
+      language: 'language',
+      translate: jest.fn(),
     };
     TestComponent = () => <span>Test</span>;
     mountTree();
@@ -36,7 +34,7 @@ describe('withTranslations higher order component', () => {
   });
 
   it('passes translations from context to props', () => {
-    const { language, translate } = testContext.translations;
+    const { language, translate } = testContext;
     const getTranslationsProp = () => mountedTree.find(TestComponent).prop('translations');
 
     expect(getTranslationsProp().language).toEqual(language);


### PR DESCRIPTION
To make the `<WithTranslations>` api equal to the < v1 api.

The `WithTranslations.spec.js` comes from an earlier version, and breaks
on v1.0.1. With the changes in this commit they pass again