### PR TITLE
Expose translateWith to enable usage outside of react context

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ const Greeting = ({ name }) => {
 };
 ```
 
+### translateWith
+
+`translateWith` is a factory function that returns the translate function, allowing access to translations out of React.
+
+Example use:
+
+```javascript
+import { translateWith } from 'retranslate';
+
+const messages = {
+  en: { key: 'I am a translation in english with a parameter here: {{ parameter }}' },
+  et: { key: 'Ma olen eestikeelne tõlge, parameetriga siin: {{ parameter }}' },
+}
+
+const translate = translateWith({ messgaes, language: 'et', fallbackLanguage: 'en' })
+const translatedMessage = translate('key', { parameter: 'foo' })
+```
+
 ## Potential questions
 
 - Async loading

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "retranslate",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "retranslate",
   "description": "Real simple translations for react.",
   "main": "dist/retranslate.js",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tankenstein/retranslate/issues",

--- a/src/core/gatherKeys.js
+++ b/src/core/gatherKeys.js
@@ -1,0 +1,24 @@
+export const gatherKeys = template => {
+  const variablePositions = [];
+  const variablePattern = /{{\s*(?<key>\w+)\s*}}/g;
+  let match;
+  let offset = 0;
+
+  // eslint-disable-next-line no-cond-assign
+  while ((match = variablePattern.exec(template))) {
+    const { index: position, groups } = match;
+    const { key } = groups;
+    const { length } = match[0];
+
+    variablePositions.push({
+      key,
+      offset,
+      position,
+      length,
+    });
+
+    offset = position + length;
+  }
+
+  return variablePositions;
+};

--- a/src/core/gatherKeys.spec.js
+++ b/src/core/gatherKeys.spec.js
@@ -1,0 +1,55 @@
+import { gatherKeys } from './gatherKeys';
+
+describe('gatherKeys', () => {
+  it('should match the key once', () => {
+    const given = '{{from}}';
+    const when = gatherKeys(given);
+    const then = [{ key: 'from', position: 0, offset: 0, length: 8 }];
+
+    expect(when).toEqual(then);
+  });
+
+  it('should ignore spaces in the curly braces', () => {
+    const given = '{{ from }}';
+    const when = gatherKeys(given);
+    const then = [{ key: 'from', position: 0, offset: 0, length: 10 }];
+
+    expect(when).toEqual(then);
+  });
+
+  it('should match the key twice', () => {
+    const given = '{{destination}} ... {{destination}}';
+    const when = gatherKeys(given);
+    const then = [
+      { key: 'destination', position: 0, offset: 0, length: 15 },
+      { key: 'destination', position: 20, offset: 15, length: 15 },
+    ];
+
+    expect(when).toEqual(then);
+  });
+
+  it('should match multiple keys', () => {
+    const given = '{{destination}} ... {{from}}';
+    const when = gatherKeys(given);
+    const then = [
+      { key: 'destination', position: 0, offset: 0, length: 15 },
+      { key: 'from', position: 20, offset: 15, length: 8 },
+    ];
+
+    expect(when).toEqual(then);
+  });
+
+  it('should match all the keys', () => {
+    const given = '{{destination}} ... {{from}} and {{ to }} then {{where}} {{to}} again';
+    const when = gatherKeys(given);
+    const then = [
+      { key: 'destination', position: 0, offset: 0, length: 15 },
+      { key: 'from', position: 20, offset: 15, length: 8 },
+      { key: 'to', offset: 28, position: 33, length: 8 },
+      { key: 'where', offset: 41, position: 47, length: 9 },
+      { key: 'to', offset: 56, position: 57, length: 6 },
+    ];
+
+    expect(when).toEqual(then);
+  });
+});

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,0 +1,1 @@
+export * from './translate';

--- a/src/core/renderTemplateParts.js
+++ b/src/core/renderTemplateParts.js
@@ -1,0 +1,15 @@
+import { gatherKeys } from './gatherKeys';
+
+export const renderTemplateParts = (template, params) => {
+  const positions = gatherKeys(template);
+  const lastPosition = positions[positions.length - 1];
+  const lastOffset = lastPosition ? lastPosition.position + lastPosition.length : 0;
+
+  return positions
+    .flatMap(({ key, offset, position }) => [
+      { dangerous: false, value: template.slice(offset, position) },
+      { dangerous: true, value: params[key] },
+    ])
+    .concat([{ dangerous: false, value: template.slice(lastOffset) }])
+    .filter(({ value }) => value);
+};

--- a/src/core/renderTemplateParts.spec.js
+++ b/src/core/renderTemplateParts.spec.js
@@ -1,0 +1,71 @@
+import { renderTemplateParts } from './renderTemplateParts';
+
+describe('renderTemplateParts', () => {
+  it('should render single key', () => {
+    const given = { template: '{{from}}', params: { from: 'Egypt' } };
+    const when = renderTemplateParts(given.template, given.params);
+    const then = [{ dangerous: true, value: 'Egypt' }];
+
+    expect(when).toEqual(then);
+  });
+
+  it('should render the key twice and the text between the occurrences', () => {
+    const given = {
+      template: '{{destination}} ... {{destination}}',
+      params: { destination: 'United Kingdom' },
+    };
+
+    const when = renderTemplateParts(given.template, given.params);
+    const then = [
+      { dangerous: true, value: 'United Kingdom' },
+      { dangerous: false, value: ' ... ' },
+      { dangerous: true, value: 'United Kingdom' },
+    ];
+
+    expect(when).toEqual(then);
+  });
+
+  it('should render multiple keys and the text between them', () => {
+    const given = {
+      template: '{{destination}} ... {{from}}',
+      params: { destination: 'United Kingdom', from: 'Egypt' },
+    };
+
+    const when = renderTemplateParts(given.template, given.params);
+    const then = [
+      { dangerous: true, value: 'United Kingdom' },
+      { dangerous: false, value: ' ... ' },
+      { dangerous: true, value: 'Egypt' },
+    ];
+
+    expect(when).toEqual(then);
+  });
+
+  it('should render all the keys and the whole template', () => {
+    const given = {
+      template: '{{destination}} ... {{from}} and {{ to }} then {{where}} {{to}} again',
+      params: {
+        destination: 'United Kingdom',
+        from: 'Egypt',
+        where: 'London',
+        to: 'Tallinn',
+      },
+    };
+
+    const when = renderTemplateParts(given.template, given.params);
+    const then = [
+      { dangerous: true, value: 'United Kingdom' },
+      { dangerous: false, value: ' ... ' },
+      { dangerous: true, value: 'Egypt' },
+      { dangerous: false, value: ' and ' },
+      { dangerous: true, value: 'Tallinn' },
+      { dangerous: false, value: ' then ' },
+      { dangerous: true, value: 'London' },
+      { dangerous: false, value: ' ' },
+      { dangerous: true, value: 'Tallinn' },
+      { dangerous: false, value: ' again' },
+    ];
+
+    expect(when).toEqual(then);
+  });
+});

--- a/src/core/translate.js
+++ b/src/core/translate.js
@@ -1,0 +1,17 @@
+import { renderTemplateParts } from './renderTemplateParts';
+
+export const translateAsParts = config => (key, parameters = {}) => {
+  const { language, messages, fallbackLanguage } = config;
+  const languageTemplate = messages[language] && messages[language][key];
+  const fallbackLanguageTemplate = messages[fallbackLanguage] && messages[fallbackLanguage][key];
+  const template = languageTemplate || fallbackLanguageTemplate;
+
+  if (template) return renderTemplateParts(template, parameters);
+
+  return [{ dangerous: false, value: key }];
+};
+
+export const translate = config => (key, parameters) =>
+  translateAsParts(config)(key, parameters)
+    .map(({ value }) => value)
+    .join('');

--- a/src/core/translate.spec.js
+++ b/src/core/translate.spec.js
@@ -1,0 +1,114 @@
+import { translateAsParts, translate } from './translate';
+
+const fallbackLanguage = 'en';
+const messages = Object.freeze({
+  en: {
+    first: 'First message.',
+    second: 'Second message with param {{ first }}.',
+    third: 'Third message with params {{ second }} and {{ third }}.',
+    missing: 'Current language is {{ language }}.',
+  },
+  et: {
+    first: 'Esimene sõnum',
+    second: 'Teine sõnum parameetriga {{ first }}.',
+    third: 'Kolmas sõnum parameetritega {{ second }} ja {{ third }}.',
+  },
+});
+
+describe('translateAsParts', () => {
+  it('should translate simple keys to et language correctly', () => {
+    const given = {
+      config: { messages, fallbackLanguage, language: 'et' },
+      key: 'first',
+    };
+
+    const when = translateAsParts(given.config)(given.key);
+    const then = [{ dangerous: false, value: 'Esimene sõnum' }];
+
+    expect(when).toEqual(then);
+  });
+
+  it('should translate dangerous key to et language correctly', () => {
+    const given = {
+      config: { messages, fallbackLanguage, language: 'et' },
+      key: 'second',
+      params: { first: 'test' },
+    };
+
+    const when = translateAsParts(given.config)(given.key, given.params);
+    const then = [
+      { dangerous: false, value: 'Teine sõnum parameetriga ' },
+      { dangerous: true, value: 'test' },
+      { dangerous: false, value: '.' },
+    ];
+
+    expect(when).toEqual(then);
+  });
+
+  it('should translate multiple dangerous key to et language correctly', () => {
+    const given = {
+      config: { messages, fallbackLanguage, language: 'et' },
+      key: 'third',
+      params: { second: 'test', third: 'foo' },
+    };
+
+    const when = translateAsParts(given.config)(given.key, given.params);
+    const then = [
+      { dangerous: false, value: 'Kolmas sõnum parameetritega ' },
+      { dangerous: true, value: 'test' },
+      { dangerous: false, value: ' ja ' },
+      { dangerous: true, value: 'foo' },
+      { dangerous: false, value: '.' },
+    ];
+
+    expect(when).toEqual(then);
+  });
+
+  it('should fallback the translation of the missing key', () => {
+    const given = {
+      config: { messages, fallbackLanguage, language: 'et' },
+      key: 'missing',
+      params: { language: 'English' },
+    };
+
+    const when = translateAsParts(given.config)(given.key, given.params);
+    const then = [
+      { dangerous: false, value: 'Current language is ' },
+      { dangerous: true, value: 'English' },
+      { dangerous: false, value: '.' },
+    ];
+
+    expect(when).toEqual(then);
+  });
+
+  it('should remove missing param part', () => {
+    const given = {
+      config: { messages, fallbackLanguage, language: 'en' },
+      key: 'second',
+      params: {},
+    };
+
+    const when = translateAsParts(given.config)(given.key, given.params);
+    const then = [
+      { dangerous: false, value: 'Second message with param ' },
+      { dangerous: false, value: '.' },
+    ];
+
+    expect(when).toEqual(then);
+  });
+});
+
+describe('translate', () => {
+  it('should translate string', () => {
+    const given = {
+      config: { messages, fallbackLanguage, language: 'et' },
+      key: 'third',
+      params: { second: 'foo', third: 'bar' },
+    };
+
+    const when = translate(given.config)(given.key, given.params);
+    const then = 'Kolmas sõnum parameetritega foo ja bar.';
+
+    expect(when).toEqual(then);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ import { Consumer as WithTranslationsComponentModule } from './common/context';
 import useTranslationsModule from './useTranslations';
 import withTranslationsModule from './withTranslations';
 
+export { translate as translateWith } from './core/translate';
+
 export const Message = MessageModule;
 export const Provider = ProviderModule;
 export const TranslationProvider = ProviderModule;

--- a/src/provider/Provider.js
+++ b/src/provider/Provider.js
@@ -2,25 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import { Provider as ContextProvider } from '../common/context';
-
-function renderTemplateIntoTemplateParts(template, params) {
-  const variablePositions = Object.keys(params)
-    .map(key => gatherMatchesForKey(template, key))
-    .reduce((result, keyMatches) => result.concat(keyMatches), [])
-    .sort((p1, p2) => p1.position - p2.position);
-  const result = [];
-  let remainingOffset = 0;
-  variablePositions.forEach(({ key, position, length }) => {
-    result.push({ dangerous: false, value: template.slice(remainingOffset, position) });
-    result.push({ dangerous: true, value: params[key] });
-    remainingOffset = position + length;
-  });
-  const leftover = template.slice(remainingOffset);
-  if (leftover.length) {
-    result.push({ dangerous: false, value: leftover });
-  }
-  return result.filter(translation => translation.value);
-}
+import { renderTemplateParts } from '../core/renderTemplateParts';
 
 class Provider extends Component {
   getContext() {
@@ -35,10 +17,10 @@ class Provider extends Component {
   translateAsParts(key, parameters = {}) {
     const { language, messages, fallbackLanguage } = this.props;
     if (messages[language] && messages[language][key]) {
-      return renderTemplateIntoTemplateParts(messages[language][key], parameters);
+      return renderTemplateParts(messages[language][key], parameters);
     }
     if (messages[fallbackLanguage] && messages[fallbackLanguage][key]) {
-      return renderTemplateIntoTemplateParts(messages[fallbackLanguage][key], parameters);
+      return renderTemplateParts(messages[fallbackLanguage][key], parameters);
     }
     return [{ dangerous: false, value: key }];
   }

--- a/src/provider/Provider.js
+++ b/src/provider/Provider.js
@@ -2,33 +2,18 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import { Provider as ContextProvider } from '../common/context';
-import { renderTemplateParts } from '../core/renderTemplateParts';
+import { translate, translateAsParts } from '../core';
 
 class Provider extends Component {
   getContext() {
-    const { language } = this.props;
+    const { language, messages, fallbackLanguage } = this.props;
+    const config = { language, messages, fallbackLanguage };
+
     return {
       language,
-      translateAsParts: this.translateAsParts.bind(this),
-      translate: this.translate.bind(this),
+      translateAsParts: translateAsParts(config),
+      translate: translate(config),
     };
-  }
-
-  translateAsParts(key, parameters = {}) {
-    const { language, messages, fallbackLanguage } = this.props;
-    if (messages[language] && messages[language][key]) {
-      return renderTemplateParts(messages[language][key], parameters);
-    }
-    if (messages[fallbackLanguage] && messages[fallbackLanguage][key]) {
-      return renderTemplateParts(messages[fallbackLanguage][key], parameters);
-    }
-    return [{ dangerous: false, value: key }];
-  }
-
-  translate(key, parameters) {
-    return this.translateAsParts(key, parameters)
-      .map(({ value }) => value)
-      .join('');
   }
 
   render() {

--- a/src/provider/Provider.js
+++ b/src/provider/Provider.js
@@ -3,30 +3,6 @@ import PropTypes from 'prop-types';
 
 import { Provider as ContextProvider } from '../common/context';
 
-function gatherMatchesForKey(template, key) {
-  const variablePositions = [];
-  const variablePattern = new RegExp(`{{\\s*${key}\\s*}}`);
-  const match = template.match(variablePattern);
-  if (match) {
-    variablePositions.push({
-      key,
-      position: match.index,
-      length: match[0].length,
-    });
-    const offset = match.index + match.length;
-    const remainingTemplate = template.slice(offset);
-    const childMatches = gatherMatchesForKey(remainingTemplate, key);
-    childMatches.forEach(childMatch => {
-      variablePositions.push({
-        key,
-        position: childMatch.position + offset,
-        length: childMatch.length,
-      });
-    });
-  }
-  return variablePositions;
-}
-
 function renderTemplateIntoTemplateParts(template, params) {
   const variablePositions = Object.keys(params)
     .map(key => gatherMatchesForKey(template, key))

--- a/src/retranslate.d.ts
+++ b/src/retranslate.d.ts
@@ -15,12 +15,14 @@ export interface Translations {
   language: string;
 }
 
-export interface ProviderProps {
-  children?: ReactNode;
+export type Messages = Record<string, Record<string, string>>
+export type Config = {
   language?: string;
   fallbackLanguage: string;
-  messages: Record<string, Record<string, string>>;
+  messages: Messages;
 }
+
+export type ProviderProps =  { children?: ReactNode; } & Config;
 export const Provider: FC<ProviderProps>;
 export const TranslationProvider: FC<ProviderProps>;
 
@@ -41,3 +43,5 @@ declare function withTranslations<P extends WithTranslationProps>(
 ): ReactNode;
 
 export const WithTranslations: FC<{ children: (translations: Translations) => ReactNode }>;
+
+declare function translateWith(config: Config): Translate;


### PR DESCRIPTION
**What is this?**
- Refactored the core functionality a bit and added more unit tests
- Extracted the core functionality from the context provider
- Exposed the core functionality as a function named **translateWith** that takes the translations config and returns the regular translate function

```ts
type Translate = (key: string, parameters?: Parameters) => string;
type Config = {
  language?: string;
  fallbackLanguage: string;
  messages: Messages;
}

declare function translateWith(config: Config): Translate;
```

**Why is this needed?**
- To enable getting translations for messages that can't live down in the the react tree.
